### PR TITLE
fixing editor example jsons

### DIFF
--- a/editor/examples/arkanoid.app.json
+++ b/editor/examples/arkanoid.app.json
@@ -1,5 +1,10 @@
 {
+	"metadata": {
+		"type": "App"
+	},
 	"project": {
+		"shadows": true,
+		"editable": true,
 		"vr": false
 	},
 	"camera": {

--- a/editor/examples/camera.app.json
+++ b/editor/examples/camera.app.json
@@ -1,4 +1,12 @@
 {
+	"metadata": {
+		"type": "App"
+	},
+	"project": {
+		"shadows": true,
+		"editable": true,
+		"vr": false
+	},
 	"camera": {
 		"metadata": {
 			"version": 4.3,


### PR DESCRIPTION
The examples for the editor were not loading on the website.  This seems to be because of the missing information in the jsons added in this branch.  These versions of the json now load on the live site.